### PR TITLE
Ensure download_url returns a string with a valid encoding

### DIFF
--- a/lib/y2status/downloader.rb
+++ b/lib/y2status/downloader.rb
@@ -16,7 +16,9 @@ module Y2status
     def download_url(url)
       print_progress("Downloading #{url}...")
       # -s silent, -L follow redirects
-      `curl --connect-timeout 15 --max-time 30 -sL #{Shellwords.escape(url)}`
+      text = `curl --connect-timeout 15 --max-time 30 -sL #{Shellwords.escape(url)}`
+      text.force_encoding("BINARY") unless text.valid_encoding?
+      text
     end
   end
 end

--- a/lib/y2status/obs_project.rb
+++ b/lib/y2status/obs_project.rb
@@ -108,7 +108,7 @@ module Y2status
       print_progress("Running \"#{cmd}\"...")
 
       begin
-        out = Timeout.timeout(15) { `#{cmd}` }
+        out = Timeout.timeout(30) { `#{cmd}` }
       rescue Timeout::Error
         @error_requests = "Command #{cmd} timed out"
         print_error(error_requests)


### PR DESCRIPTION
Most strings will be correct UTF-8 but those that aren't will be marked as binary.

This fixes:

```
Downloading https://ci.suse.de/view/YaST/job/yast-POT-updater/lastBuild/consoleText...
/home/jenkins/workspace/yast-status-check/lib/y2status/jenkins_log_analyzer.rb:19:in `author': invalid byte sequence in UTF-8 (ArgumentError)
	from /home/jenkins/workspace/yast-status-check/lib/y2status/../../views/_jenkins.html.erb:35:in `block (2 levels) in context'
```

Caused by "LANG=zh_CN msgmerge ..." whih outputs non-UTF-8.