### PR TITLE
UTF-8 fix, increased `osc prjresults` time out

### DIFF
--- a/lib/y2status/log_analyzer.rb
+++ b/lib/y2status/log_analyzer.rb
@@ -6,7 +6,8 @@ module Y2status
     attr_reader :log
 
     def initialize(log)
-      @log = log
+      # remove invalid UTF-8 characters in the log so string operations do not crash with exception
+      @log = log.encode(::Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "")
     end
 
     #

--- a/lib/y2status/obs_project.rb
+++ b/lib/y2status/obs_project.rb
@@ -108,7 +108,7 @@ module Y2status
       print_progress("Running \"#{cmd}\"...")
 
       begin
-        out = Timeout.timeout(15) { `#{cmd}` }
+        out = Timeout.timeout(60) { `#{cmd}` }
       rescue Timeout::Error
         @error_requests = "Command #{cmd} timed out"
         print_error(error_requests)


### PR DESCRIPTION
### UTF-8 Fix

#### The Problem

The log analyzer could crash if the downloaded log contained invalid UTF-8 characters:

```
/home/jenkins/workspace/yast-status-check/lib/y2status/jenkins_log_analyzer.rb:19:in `author':
 invalid byte sequence in UTF-8 (ArgumentError)
```
See for example https://ci.suse.de/view/YaST/job/yast-status-check/35270/console

#### The Fix

Just sanitize the log before analyzing it.

---

### OSC Time Out

#### The Problem

The dashboard generated in Jenkins contains this error "Command osc prjresults --csv system:install:head timed out". The problem is that the default 15 second time out is too short for this call.

It takes about 12 seconds on my system:

```console
# time osc prjresults --csv system:install:head > /dev/null

real	0m11,990s
user	0m11,764s
sys	0m0,027s
```
In the Jenkins worker in might be a bit slower reaching the time out.

#### The Fix

Increase the time out, one minute should be enough in most cases.