### PR TITLE
Added badge for the HTTP server packages check

### DIFF
--- a/views/_checks.html.erb
+++ b/views/_checks.html.erb
@@ -13,3 +13,11 @@
       alt="Systemd Status Check"/>
   </a>
 </p>
+
+<h4>Available HTTP Server Packages</h4>
+<p>
+  <a href="https://github.com/yast/yast-http-server/actions/workflows/packages.yml?query=branch%3Amaster">
+    <img src="https://github.com/yast/yast-http-server/actions/workflows/packages.yml/badge.svg?branch=master"
+      alt="HTTP Server Packages"/>
+  </a>
+</p>


### PR DESCRIPTION
Display the [![Available_Packages](https://github.com/yast/yast-http-server/actions/workflows/packages.yml/badge.svg)](https://github.com/yast/yast-http-server/actions/workflows/packages.yml) badge in the dashboard.